### PR TITLE
Add a preference to make Hot Edge activatable on fullscreen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+schemas/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 build/
-schemas/
+schemas/gschemas.compiled

--- a/extension.js
+++ b/extension.js
@@ -71,7 +71,6 @@ class Extension {
         let pressureThreshold = this._settings.get_uint('pressure-threshold');
         let fallbackTimeout = this._settings.get_uint('fallback-timeout');
         let edgeSize = this._settings.get_uint('edge-size') / 100;
-        let suppressActivationWhenButtonHeld = this._settings.get_boolean('suppress-activation-when-button-held')
         LOGGER.debug('pressureThreshold ' + pressureThreshold);
         LOGGER.debug('fallbackTimeout ' + fallbackTimeout);
         LOGGER.debug('edgeSize ' + edgeSize);

--- a/extension.js
+++ b/extension.js
@@ -128,6 +128,7 @@ class HotEdge extends Clutter.Actor {
         this._fallbackTimeout = this._settings.get_uint('fallback-timeout');
         this._edgeSize = this._settings.get_uint('edge-size') / 100;
         this._suppressActivationWhenButtonHeld = this._settings.get_boolean('suppress-activation-when-button-held');
+        this._suppressActivationWhenFullscreen = this._settings.get_boolean('suppress-activation-when-fullscreen')
 
         this._setupFallbackEdgeIfNeeded(layoutManager);
 
@@ -194,7 +195,7 @@ class HotEdge extends Clutter.Actor {
             return;
         }
 
-        if (this._monitor.inFullscreen && !Main.overview.visible)
+        if (this._suppressActivationWhenFullscreen && this._monitor.inFullscreen && !Main.overview.visible)
             return;
 
         if (Main.overview.shouldToggleByCornerOrButton()) {

--- a/prefs.js
+++ b/prefs.js
@@ -136,7 +136,7 @@ function buildPrefsWidget() {
 
     // suppress-activation-when-fullscreen
     let suppressActivationFullscreenLabel = new Gtk.Label({
-        label: "Don't activate when monitor is fullscreen",
+        label: "Don't activate when an application is fullscreen",
         halign: Gtk.Align.START,
         hexpand: true,
         visible: true

--- a/prefs.js
+++ b/prefs.js
@@ -112,24 +112,24 @@ function buildPrefsWidget() {
     );  
 
     // suppress-activation-when-button-held
-    let suppressActivationLabel = new Gtk.Label({
+    let suppressActivationButtonHeldLabel = new Gtk.Label({
         label: "Don't activate when a button is held",
         halign: Gtk.Align.START,
         hexpand: true,
         visible: true
     });
-    prefsWidget.attach(suppressActivationLabel, 0, 2, 1, 1);
+    prefsWidget.attach(suppressActivationButtonHeldLabel, 0, 2, 1, 1);
 
-    let suppressActivationInput = new Gtk.Switch({
+    let suppressActivationButtonHeldInput = new Gtk.Switch({
         halign: Gtk.Align.END,
         hexpand: true,
         visible: true
     });
-    prefsWidget.attach(suppressActivationInput, 1, 2, 1, 1);
+    prefsWidget.attach(suppressActivationButtonHeldInput, 1, 2, 1, 1);
 
     this.settings.bind(
         'suppress-activation-when-button-held',
-        suppressActivationInput,
+        suppressActivationButtonHeldInput,
         'active',
         Gio.SettingsBindFlags.DEFAULT
     );  

--- a/prefs.js
+++ b/prefs.js
@@ -133,7 +133,30 @@ function buildPrefsWidget() {
         'active',
         Gio.SettingsBindFlags.DEFAULT
     );  
-    
+
+    // suppress-activation-when-fullscreen
+    let suppressActivationFullscreenLabel = new Gtk.Label({
+        label: "Don't activate when monitor is fullscreen",
+        halign: Gtk.Align.START,
+        hexpand: true,
+        visible: true
+    });
+    prefsWidget.attach(suppressActivationFullscreenLabel, 0, 3, 1, 1);
+
+    let suppressActivationFullscreenInput = new Gtk.Switch({
+        halign: Gtk.Align.END,
+        hexpand: true,
+        visible: true
+    });
+    prefsWidget.attach(suppressActivationFullscreenInput, 1, 3, 1, 1);
+
+    this.settings.bind(
+        'suppress-activation-when-fullscreen',
+        suppressActivationFullscreenInput,
+        'active',
+        Gio.SettingsBindFlags.DEFAULT
+    );
+
     // min-log-level
     let logLevelLabel = new Gtk.Label({
         label: 'Log Level',
@@ -141,7 +164,7 @@ function buildPrefsWidget() {
         hexpand: true,
         visible: true
     });
-    prefsWidget.attach(logLevelLabel, 0, 3, 1, 1);
+    prefsWidget.attach(logLevelLabel, 0, 4, 1, 1);
 
     let logLevelInput = new Gtk.SpinButton({
         adjustment: new Gtk.Adjustment({
@@ -153,7 +176,7 @@ function buildPrefsWidget() {
         hexpand: true,
         visible: true
     });
-    prefsWidget.attach(logLevelInput, 1, 3, 1, 1);
+    prefsWidget.attach(logLevelInput, 1, 4, 1, 1);
 
     this.settings.bind(
         'min-log-level',

--- a/schemas/org.gnome.shell.extensions.hotedge.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.hotedge.gschema.xml
@@ -22,6 +22,10 @@
       <summary>If set to true, then when a mouse button is held down don't activate the overview.</summary>
       <default>true</default>
     </key>
+    <key name="suppress-activation-when-fullscreen" type="b">
+      <summary>If set to true, it won't activate the overview if a fullscreen window is focused.</summary>
+      <default>true</default>
+    </key>
     <key name="fallback-in-use" type="b">
       <summary>Set by the extension, indicates whether or not the time-based activation fallback method is in use.</summary>
       <default>false</default>


### PR DESCRIPTION
Add a new preference to allow users to choose weather or not they want Hot Edge to be activatable when a fullscreen window is focused. Here's a quick demo:

[Fullscreen preference demo](https://user-images.githubusercontent.com/65264536/196776266-326db0aa-c6f8-4e00-ad23-cdf7ef9dc8c5.webm)

By default, this preference keeps the previous behavior (that is, Hot Edge is suppressed on fullscreen) so it is coherent with GNOME's original Hot Corner.

Along the way I also made a few smaller changes, like removing an unused variable and adding a few directories to `.gitignore`. These are in separate commits, for your reviewing convenience.

Thanks for developing this awesome extension! 🚀 
