### PR TITLE
Ignore all mouse buttons when option is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Hot Edge exposes two settings that alter its sensitivity : `pressure-threshold` 
 
 ### suppress-activation-when-button-held
 
-When `suppress-activation-when-button-held` is true the hot edge will not activate when a mouse button is held down. This reduces the chance of accidental activation, but also prevents you from using th ehot edge to open the shell during drag-and-drop operations.
+When `suppress-activation-when-button-held` is true the hot edge will not activate when a mouse button is held down. This reduces the chance of accidental activation, but also prevents you from using the hot edge to open the shell during drag-and-drop operations. When true, `suppress-button-option-left`, `suppress-button-option-right`, and `suppress-button-option-middle` can be used to enable this feature for these mouse buttons individually.
 
 ### suppress-activation-when-fullscreen
  

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Hot Edge exposes two settings that alter its sensitivity : `pressure-threshold` 
 
 ### suppress-activation-when-button-held
 
-When `suppress-activation-when-button-held` is true the hot edge will not activate when a mouse button is held down. This reduces the chance of accidental activation, but also prevents you from using the hot edge to open the shell during drag-and-drop operations. When true, `suppress-button-option-left`, `suppress-button-option-right`, and `suppress-button-option-middle` can be used to enable this feature for these mouse buttons individually.
+When `suppress-activation-when-button-held` is true the hot edge will not activate when a mouse button is held down. This reduces the chance of accidental activation, but also prevents you from using the hot edge to open the shell during drag-and-drop operations.
 
 ### suppress-activation-when-fullscreen
  

--- a/extension.js
+++ b/extension.js
@@ -129,13 +129,13 @@ const HotEdge = GObject.registerClass(
             this._edgeSize = this._settings.get_uint("edge-size") / 100;
 
             this._suppressActivationWhenButtonHeld = this._settings.get_boolean("suppress-activation-when-button-held");
-            this._suppressActivationWhenButtonHeldLeft = this._settings.get_boolean("suppress-activation-when-button-held-left");
-            this._suppressActivationWhenButtonHeldRight = this._settings.get_boolean("suppress-activation-when-button-held-right");
-            this._suppressActivationWhenButtonHeldMiddle = this._settings.get_boolean("suppress-activation-when-button-held-middle");
+            this._suppressButtonOptionLeft = this._settings.get_boolean("suppress-button-option-left");
+            this._suppressButtonOptionRight = this._settings.get_boolean("suppress-button-option-right");
+            this._suppressButtonOptionMiddle = this._settings.get_boolean("suppress-button-option-middle");
             this._ignoredButtons = [];
-            if (this._suppressActivationWhenButtonHeldLeft) this._ignoredButtons.push(Clutter.ModifierType.BUTTON1_MASK);
-            if (this._suppressActivationWhenButtonHeldRight) this._ignoredButtons.push(Clutter.ModifierType.BUTTON2_MASK);
-            if (this._suppressActivationWhenButtonHeldMiddle) this._ignoredButtons.push(Clutter.ModifierType.BUTTON3_MASK);
+            if (this._suppressButtonOptionLeft) this._ignoredButtons.push(Clutter.ModifierType.BUTTON1_MASK);
+            if (this._suppressButtonOptionRight) this._ignoredButtons.push(Clutter.ModifierType.BUTTON2_MASK);
+            if (this._suppressButtonOptionMiddle) this._ignoredButtons.push(Clutter.ModifierType.BUTTON3_MASK);
 
             this._suppressActivationWhenFullscreen = this._settings.get_boolean("suppress-activation-when-fullscreen");
             this._showAnimation = this._settings.get_boolean("show-animation");

--- a/extension.js
+++ b/extension.js
@@ -129,13 +129,11 @@ const HotEdge = GObject.registerClass(
             this._edgeSize = this._settings.get_uint("edge-size") / 100;
 
             this._suppressActivationWhenButtonHeld = this._settings.get_boolean("suppress-activation-when-button-held");
-            this._suppressButtonOptionLeft = this._settings.get_boolean("suppress-button-option-left");
-            this._suppressButtonOptionRight = this._settings.get_boolean("suppress-button-option-right");
-            this._suppressButtonOptionMiddle = this._settings.get_boolean("suppress-button-option-middle");
-            this._ignoredButtons = [];
-            if (this._suppressButtonOptionLeft) this._ignoredButtons.push(Clutter.ModifierType.BUTTON1_MASK);
-            if (this._suppressButtonOptionRight) this._ignoredButtons.push(Clutter.ModifierType.BUTTON2_MASK);
-            if (this._suppressButtonOptionMiddle) this._ignoredButtons.push(Clutter.ModifierType.BUTTON3_MASK);
+            this._ignoredButtons = [
+                Clutter.ModifierType.BUTTON1_MASK,
+                Clutter.ModifierType.BUTTON2_MASK,
+                Clutter.ModifierType.BUTTON3_MASK,
+            ];
 
             this._suppressActivationWhenFullscreen = this._settings.get_boolean("suppress-activation-when-fullscreen");
             this._showAnimation = this._settings.get_boolean("show-animation");

--- a/extension.js
+++ b/extension.js
@@ -143,6 +143,12 @@ const HotEdge = GObject.registerClass(
             this._ripples = new Ripples.Ripples(0.5, 0.5, "ripple-centered");
             this._ripples.addTo(layoutManager.uiGroup);
 
+            this._ignoredButtons = [
+                Clutter.ModifierType.BUTTON1_MASK,
+                Clutter.ModifierType.BUTTON2_MASK,
+                Clutter.ModifierType.BUTTON3_MASK,
+            ]
+
             this.connect("destroy", this._onDestroy.bind(this));
         }
 
@@ -201,8 +207,11 @@ const HotEdge = GObject.registerClass(
         }
 
         _toggleOverview() {
-            if (this._suppressActivationWhenButtonHeld && global.get_pointer()[2] & Clutter.ModifierType.BUTTON1_MASK) {
-                return;
+            if (this._suppressActivationWhenButtonHeld) {
+                let buttonHeld = this._ignoredButtons.some(button => (global.get_pointer()[2] & button) !== 0);
+                if (buttonHeld) {
+                    return;
+                }
             }
 
             if (this._suppressActivationWhenFullscreen && this._monitor.inFullscreen && !Main.overview.visible) return;

--- a/extension.js
+++ b/extension.js
@@ -127,7 +127,16 @@ const HotEdge = GObject.registerClass(
             this._settings = settings;
             this._fallbackTimeout = this._settings.get_uint("fallback-timeout");
             this._edgeSize = this._settings.get_uint("edge-size") / 100;
+
             this._suppressActivationWhenButtonHeld = this._settings.get_boolean("suppress-activation-when-button-held");
+            this._suppressActivationWhenButtonHeldLeft = this._settings.get_boolean("suppress-activation-when-button-held-left");
+            this._suppressActivationWhenButtonHeldRight = this._settings.get_boolean("suppress-activation-when-button-held-right");
+            this._suppressActivationWhenButtonHeldMiddle = this._settings.get_boolean("suppress-activation-when-button-held-middle");
+            this._ignoredButtons = [];
+            if (this._suppressActivationWhenButtonHeldLeft) this._ignoredButtons.push(Clutter.ModifierType.BUTTON1_MASK);
+            if (this._suppressActivationWhenButtonHeldRight) this._ignoredButtons.push(Clutter.ModifierType.BUTTON2_MASK);
+            if (this._suppressActivationWhenButtonHeldMiddle) this._ignoredButtons.push(Clutter.ModifierType.BUTTON3_MASK);
+
             this._suppressActivationWhenFullscreen = this._settings.get_boolean("suppress-activation-when-fullscreen");
             this._showAnimation = this._settings.get_boolean("show-animation");
 
@@ -142,12 +151,6 @@ const HotEdge = GObject.registerClass(
             this._pressureBarrier.connect("trigger", this._toggleOverview.bind(this));
             this._ripples = new Ripples.Ripples(0.5, 0.5, "ripple-centered");
             this._ripples.addTo(layoutManager.uiGroup);
-
-            this._ignoredButtons = [
-                Clutter.ModifierType.BUTTON1_MASK,
-                Clutter.ModifierType.BUTTON2_MASK,
-                Clutter.ModifierType.BUTTON3_MASK,
-            ]
 
             this.connect("destroy", this._onDestroy.bind(this));
         }

--- a/prefs.js
+++ b/prefs.js
@@ -80,7 +80,8 @@ export default class HotEdgePreferences extends ExtensionPreferences {
 
         // suppress-activation-when-button-held
         const suppressWhenButtonHeldRow = new Adw.ExpanderRow({
-            title: "Don't activate when a mouse button is held",
+            title: "Suppress on mouse button",
+            subtitle: "Don't activate overview while a mouse button is held",
             show_enable_switch: true,
         });
         settings.bind(
@@ -93,7 +94,7 @@ export default class HotEdgePreferences extends ExtensionPreferences {
 
         // suppress-activation-when-button-held-left
         const suppressWhenButtonHeldLeftRow = new Adw.SwitchRow({
-            title: "Left Mouse Button",
+            title: "Left mouse button",
         });
         settings.bind(
             "suppress-activation-when-button-held-left",
@@ -105,7 +106,7 @@ export default class HotEdgePreferences extends ExtensionPreferences {
 
         // suppress-activation-when-button-held-right
         const suppressWhenButtonHeldRightRow = new Adw.SwitchRow({
-            title: "Right Mouse Button",
+            title: "Right mouse button",
         });
         settings.bind(
             "suppress-activation-when-button-held-right",
@@ -117,7 +118,7 @@ export default class HotEdgePreferences extends ExtensionPreferences {
 
         // suppress-activation-when-button-held-middle
         const suppressWhenButtonHeldMiddleRow = new Adw.SwitchRow({
-            title: "Middle Mouse Button",
+            title: "Middle mouse button",
         });
         settings.bind(
             "suppress-activation-when-button-held-middle",
@@ -129,7 +130,8 @@ export default class HotEdgePreferences extends ExtensionPreferences {
 
         // suppress-activation-when-fullscreen
         const suppressWhenFullscreenRow = new Adw.SwitchRow({
-            title: "Don't activate when an application is fullscreen",
+            title: "Suppress on fullscreen",
+            subtitle: "Don't activate overview while an application is displayed in fullscreen mode",
         });
         settings.bind(
             "suppress-activation-when-fullscreen",

--- a/prefs.js
+++ b/prefs.js
@@ -87,7 +87,7 @@ export default class HotEdgePreferences extends ExtensionPreferences {
         settings.bind(
             "suppress-activation-when-button-held",
             suppressWhenButtonHeldRow,
-            "active",
+            "enable-expansion",
             Gio.SettingsBindFlags.DEFAULT,
         );
         behaviorGroup.add(suppressWhenButtonHeldRow);

--- a/prefs.js
+++ b/prefs.js
@@ -79,8 +79,9 @@ export default class HotEdgePreferences extends ExtensionPreferences {
         behaviorGroup.add(edgeSizeRow);
 
         // suppress-activation-when-button-held
-        const suppressWhenButtonHeldRow = new Adw.SwitchRow({
+        const suppressWhenButtonHeldRow = new Adw.ExpanderRow({
             title: "Don't activate when a mouse button is held",
+            show_enable_switch: true,
         });
         settings.bind(
             "suppress-activation-when-button-held",
@@ -92,7 +93,7 @@ export default class HotEdgePreferences extends ExtensionPreferences {
 
         // suppress-activation-when-button-held-left
         const suppressWhenButtonHeldLeftRow = new Adw.SwitchRow({
-            title: "Don't activate when the left mouse button is held",
+            title: "Left Mouse Button",
         });
         settings.bind(
             "suppress-activation-when-button-held-left",
@@ -100,11 +101,11 @@ export default class HotEdgePreferences extends ExtensionPreferences {
             "active",
             Gio.SettingsBindFlags.DEFAULT,
         );
-        behaviorGroup.add(suppressWhenButtonHeldLeftRow);
+        suppressWhenButtonHeldRow.add_row(suppressWhenButtonHeldLeftRow);
 
         // suppress-activation-when-button-held-right
         const suppressWhenButtonHeldRightRow = new Adw.SwitchRow({
-            title: "Don't activate when the right mouse button is held",
+            title: "Right Mouse Button",
         });
         settings.bind(
             "suppress-activation-when-button-held-right",
@@ -112,11 +113,11 @@ export default class HotEdgePreferences extends ExtensionPreferences {
             "active",
             Gio.SettingsBindFlags.DEFAULT,
         );
-        behaviorGroup.add(suppressWhenButtonHeldRightRow);
+        suppressWhenButtonHeldRow.add_row(suppressWhenButtonHeldRightRow);
 
         // suppress-activation-when-button-held-middle
         const suppressWhenButtonHeldMiddleRow = new Adw.SwitchRow({
-            title: "Don't activate when the middle mouse button is held",
+            title: "Middle Mouse Button",
         });
         settings.bind(
             "suppress-activation-when-button-held-middle",
@@ -124,7 +125,7 @@ export default class HotEdgePreferences extends ExtensionPreferences {
             "active",
             Gio.SettingsBindFlags.DEFAULT,
         );
-        behaviorGroup.add(suppressWhenButtonHeldMiddleRow);
+        suppressWhenButtonHeldRow.add_row(suppressWhenButtonHeldMiddleRow);
 
         // suppress-activation-when-fullscreen
         const suppressWhenFullscreenRow = new Adw.SwitchRow({

--- a/prefs.js
+++ b/prefs.js
@@ -79,54 +79,17 @@ export default class HotEdgePreferences extends ExtensionPreferences {
         behaviorGroup.add(edgeSizeRow);
 
         // suppress-activation-when-button-held
-        const suppressWhenButtonHeldRow = new Adw.ExpanderRow({
+        const suppressWhenButtonHeldRow = new Adw.SwitchRow({
             title: "Suppress on mouse button",
             subtitle: "Don't activate overview while a mouse button is held",
-            show_enable_switch: true,
         });
         settings.bind(
             "suppress-activation-when-button-held",
             suppressWhenButtonHeldRow,
-            "enable-expansion",
+            "active",
             Gio.SettingsBindFlags.DEFAULT,
         );
         behaviorGroup.add(suppressWhenButtonHeldRow);
-
-        // suppress-button-option-left
-        const suppressButtonOptionLeft = new Adw.SwitchRow({
-            title: "Left mouse button",
-        });
-        settings.bind(
-            "suppress-button-option-left",
-            suppressButtonOptionLeft,
-            "active",
-            Gio.SettingsBindFlags.DEFAULT,
-        );
-        suppressWhenButtonHeldRow.add_row(suppressButtonOptionLeft);
-
-        // suppress-button-option-right
-        const suppressButtonOptionRight = new Adw.SwitchRow({
-            title: "Right mouse button",
-        });
-        settings.bind(
-            "suppress-button-option-right",
-            suppressButtonOptionRight,
-            "active",
-            Gio.SettingsBindFlags.DEFAULT,
-        );
-        suppressWhenButtonHeldRow.add_row(suppressButtonOptionRight);
-
-        // suppress-button-option-middle
-        const suppressButtonOptionMiddle = new Adw.SwitchRow({
-            title: "Middle mouse button",
-        });
-        settings.bind(
-            "suppress-button-option-middle",
-            suppressButtonOptionMiddle,
-            "active",
-            Gio.SettingsBindFlags.DEFAULT,
-        );
-        suppressWhenButtonHeldRow.add_row(suppressButtonOptionMiddle);
 
         // suppress-activation-when-fullscreen
         const suppressWhenFullscreenRow = new Adw.SwitchRow({

--- a/prefs.js
+++ b/prefs.js
@@ -92,41 +92,41 @@ export default class HotEdgePreferences extends ExtensionPreferences {
         );
         behaviorGroup.add(suppressWhenButtonHeldRow);
 
-        // suppress-activation-when-button-held-left
-        const suppressWhenButtonHeldLeftRow = new Adw.SwitchRow({
+        // suppress-button-option-left
+        const suppressButtonOptionLeft = new Adw.SwitchRow({
             title: "Left mouse button",
         });
         settings.bind(
-            "suppress-activation-when-button-held-left",
-            suppressWhenButtonHeldLeftRow,
+            "suppress-button-option-left",
+            suppressButtonOptionLeft,
             "active",
             Gio.SettingsBindFlags.DEFAULT,
         );
-        suppressWhenButtonHeldRow.add_row(suppressWhenButtonHeldLeftRow);
+        suppressWhenButtonHeldRow.add_row(suppressButtonOptionLeft);
 
-        // suppress-activation-when-button-held-right
-        const suppressWhenButtonHeldRightRow = new Adw.SwitchRow({
+        // suppress-button-option-right
+        const suppressButtonOptionRight = new Adw.SwitchRow({
             title: "Right mouse button",
         });
         settings.bind(
-            "suppress-activation-when-button-held-right",
-            suppressWhenButtonHeldRightRow,
+            "suppress-button-option-right",
+            suppressButtonOptionRight,
             "active",
             Gio.SettingsBindFlags.DEFAULT,
         );
-        suppressWhenButtonHeldRow.add_row(suppressWhenButtonHeldRightRow);
+        suppressWhenButtonHeldRow.add_row(suppressButtonOptionRight);
 
-        // suppress-activation-when-button-held-middle
-        const suppressWhenButtonHeldMiddleRow = new Adw.SwitchRow({
+        // suppress-button-option-middle
+        const suppressButtonOptionMiddle = new Adw.SwitchRow({
             title: "Middle mouse button",
         });
         settings.bind(
-            "suppress-activation-when-button-held-middle",
-            suppressWhenButtonHeldMiddleRow,
+            "suppress-button-option-middle",
+            suppressButtonOptionMiddle,
             "active",
             Gio.SettingsBindFlags.DEFAULT,
         );
-        suppressWhenButtonHeldRow.add_row(suppressWhenButtonHeldMiddleRow);
+        suppressWhenButtonHeldRow.add_row(suppressButtonOptionMiddle);
 
         // suppress-activation-when-fullscreen
         const suppressWhenFullscreenRow = new Adw.SwitchRow({

--- a/prefs.js
+++ b/prefs.js
@@ -90,6 +90,42 @@ export default class HotEdgePreferences extends ExtensionPreferences {
         );
         behaviorGroup.add(suppressWhenButtonHeldRow);
 
+        // suppress-activation-when-button-held-left
+        const suppressWhenButtonHeldLeftRow = new Adw.SwitchRow({
+            title: "Don't activate when the left mouse button is held",
+        });
+        settings.bind(
+            "suppress-activation-when-button-held-left",
+            suppressWhenButtonHeldLeftRow,
+            "active",
+            Gio.SettingsBindFlags.DEFAULT,
+        );
+        behaviorGroup.add(suppressWhenButtonHeldLeftRow);
+
+        // suppress-activation-when-button-held-right
+        const suppressWhenButtonHeldRightRow = new Adw.SwitchRow({
+            title: "Don't activate when the right mouse button is held",
+        });
+        settings.bind(
+            "suppress-activation-when-button-held-right",
+            suppressWhenButtonHeldRightRow,
+            "active",
+            Gio.SettingsBindFlags.DEFAULT,
+        );
+        behaviorGroup.add(suppressWhenButtonHeldRightRow);
+
+        // suppress-activation-when-button-held-middle
+        const suppressWhenButtonHeldMiddleRow = new Adw.SwitchRow({
+            title: "Don't activate when the middle mouse button is held",
+        });
+        settings.bind(
+            "suppress-activation-when-button-held-middle",
+            suppressWhenButtonHeldMiddleRow,
+            "active",
+            Gio.SettingsBindFlags.DEFAULT,
+        );
+        behaviorGroup.add(suppressWhenButtonHeldMiddleRow);
+
         // suppress-activation-when-fullscreen
         const suppressWhenFullscreenRow = new Adw.SwitchRow({
             title: "Don't activate when an application is fullscreen",

--- a/schemas/org.gnome.shell.extensions.hotedge.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.hotedge.gschema.xml
@@ -22,6 +22,18 @@
       <summary>Don't activate the overview when a mouse button is held down.</summary>
       <default>true</default>
     </key>
+    <key name="suppress-activation-when-button-held-left" type="b">
+      <summary>Don't activate the overview when the left mouse button is held down.</summary>
+      <default>true</default>
+    </key>
+    <key name="suppress-activation-when-button-held-right" type="b">
+      <summary>Don't activate the overview when the right mouse button is held down.</summary>
+      <default>true</default>
+    </key>
+    <key name="suppress-activation-when-button-held-middle" type="b">
+      <summary>Don't activate the overview when the middle mouse button is held down.</summary>
+      <default>true</default>
+    </key>
     <key name="suppress-activation-when-fullscreen" type="b">
       <summary>Don't activate the overview if a fullscreen window is focused.</summary>
       <default>true</default>

--- a/schemas/org.gnome.shell.extensions.hotedge.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.hotedge.gschema.xml
@@ -22,18 +22,6 @@
       <summary>Don't activate the overview when a mouse button is held down.</summary>
       <default>true</default>
     </key>
-    <key name="suppress-button-option-left" type="b">
-      <summary>Don't activate the overview when the left mouse button is held down.</summary>
-      <default>true</default>
-    </key>
-    <key name="suppress-button-option-right" type="b">
-      <summary>Don't activate the overview when the right mouse button is held down.</summary>
-      <default>true</default>
-    </key>
-    <key name="suppress-button-option-middle" type="b">
-      <summary>Don't activate the overview when the middle mouse button is held down.</summary>
-      <default>true</default>
-    </key>
     <key name="suppress-activation-when-fullscreen" type="b">
       <summary>Don't activate the overview if a fullscreen window is focused.</summary>
       <default>true</default>

--- a/schemas/org.gnome.shell.extensions.hotedge.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.hotedge.gschema.xml
@@ -22,15 +22,15 @@
       <summary>Don't activate the overview when a mouse button is held down.</summary>
       <default>true</default>
     </key>
-    <key name="suppress-activation-when-button-held-left" type="b">
+    <key name="suppress-button-option-left" type="b">
       <summary>Don't activate the overview when the left mouse button is held down.</summary>
       <default>true</default>
     </key>
-    <key name="suppress-activation-when-button-held-right" type="b">
+    <key name="suppress-button-option-right" type="b">
       <summary>Don't activate the overview when the right mouse button is held down.</summary>
       <default>true</default>
     </key>
-    <key name="suppress-activation-when-button-held-middle" type="b">
+    <key name="suppress-button-option-middle" type="b">
       <summary>Don't activate the overview when the middle mouse button is held down.</summary>
       <default>true</default>
     </key>


### PR DESCRIPTION
Added support for right and middle mouse buttons when `suppress-activation-when-button-held` option is enabled. Previously, only the left button stopped the overview from activating. This can be annoying for example when using the middle mouse button to scroll in some apps.

Also added three new preferences in an expandable menu so all three buttons can be toggled individually. All three default to true to match the description "when a mouse button is pressed".